### PR TITLE
Dotnet pack and version update

### DIFF
--- a/plugin/src/main/java/org/eobjects/build/CsProjFile.java
+++ b/plugin/src/main/java/org/eobjects/build/CsProjFile.java
@@ -146,6 +146,8 @@ public class CsProjFile implements DotnetProjectFile {
 
         setVersionPart("VersionPrefix", versionPrefix, "VersionSuffix");
         setVersionPart("VersionSuffix", versionSuffix, "VersionPrefix");
+        // Remove the Version tag if it exists.
+        setVersionPart("Version", null, null);
     }
 
     @Override

--- a/plugin/src/main/java/org/eobjects/build/DotnetPackMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/DotnetPackMojo.java
@@ -35,8 +35,7 @@ public class DotnetPackMojo extends AbstractDotnetMojo {
         final PluginHelper helper = getPluginHelper();
         for (File subDirectory : helper.getProjectDirectories()) {
             final String output = helper.getNugetPackageDir(subDirectory).getPath();
-            helper.executeCommand(subDirectory, "dotnet", "pack", "-o", output, "-c", helper.getBuildConfiguration(),
-                    "--version-suffix", version);
+            helper.executeCommand(subDirectory, "dotnet", "pack", "-o", output, "-c", helper.getBuildConfiguration());
 
             final DotnetProjectFile projectFile = getPluginHelper().getProjectFile(subDirectory);
 

--- a/plugin/src/test/java/org/eobjects/build/CsProjFileTest.java
+++ b/plugin/src/test/java/org/eobjects/build/CsProjFileTest.java
@@ -26,7 +26,7 @@ public class CsProjFileTest {
 
     @Test
     public void testGetVersion() {
-        assertThat(file1_xUnit.getVersion()).isNull();
+        assertThat(file1_xUnit.getVersion()).isEqualTo("LegacyVersionToBeRemoved");
         assertThat(file2_msTest.getVersion()).isNull();
         assertThat(file3_webApp.getVersion()).isNotNull().isEqualTo("1.3.1-alpha");
     }

--- a/plugin/src/test/java/org/eobjects/build/CsProjFileTest.java
+++ b/plugin/src/test/java/org/eobjects/build/CsProjFileTest.java
@@ -86,7 +86,7 @@ public class CsProjFileTest {
         }
         Files.copy(file1_xUnit.getFile().toPath(), testFile.toPath());
 
-        assertThat(getVersion(testFile)).isNull();
+        assertThat(getVersion(testFile)).isEqualTo("LegacyVersionToBeRemoved");
 
         final DotnetProjectFile projectFile = new CsProjFile(testFile, null);
         projectFile.setVersion("42.1337.0");

--- a/plugin/src/test/resources/example1-xunit.csproj
+++ b/plugin/src/test/resources/example1-xunit.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <Version>LegacyVersionToBeRemoved</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Removed the `--version-prefix` argument from the `dotnet pack` operation. It was determined that the `.csproj` will contain the desired version.
* Updated unit tests
* Added code to remove the legacy `Version` tag when updating a `.csproj` version.