### PR TITLE
Add support for PACKING & TESTING of identified framework

### DIFF
--- a/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
@@ -23,7 +23,7 @@ public abstract class AbstractDotnetMojo extends AbstractMojo {
     @Parameter(property = "dotnet.configuration", required = false, defaultValue = "Release")
     private String buildConfiguration;
 
-    @Parameter(property = PluginHelper.PROPERTY_TARGET_FRAMEWORK, required = false, defaultValue = "")
+    @Parameter(property = "dotnet.build.framework", required = false, defaultValue = "")
     private String buildTargetFramework;
 
     public PluginHelper getPluginHelper() {

--- a/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
@@ -23,7 +23,7 @@ public abstract class AbstractDotnetMojo extends AbstractMojo {
     @Parameter(property = "dotnet.configuration", required = false, defaultValue = "Release")
     private String buildConfiguration;
 
-    @Parameter(property = "dotnet.build.framework", required = false, defaultValue = "")
+    @Parameter(property = PluginHelper.PROPERTY_TARGET_FRAMEWORK, required = false, defaultValue = "")
     private String buildTargetFramework;
 
     public PluginHelper getPluginHelper() {

--- a/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/AbstractDotnetMojo.java
@@ -23,7 +23,10 @@ public abstract class AbstractDotnetMojo extends AbstractMojo {
     @Parameter(property = "dotnet.configuration", required = false, defaultValue = "Release")
     private String buildConfiguration;
 
+    @Parameter(property = "dotnet.build.framework", required = false, defaultValue = "")
+    private String buildTargetFramework;
+
     public PluginHelper getPluginHelper() {
-        return PluginHelper.get(getLog(), basedir, environment, packOutput, buildConfiguration, skip);
+        return PluginHelper.get(getLog(), basedir, environment, packOutput, buildConfiguration, buildTargetFramework, skip);
     }
 }

--- a/plugin/src/main/java/org/eobjects/build/AbstractDotnetTestMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/AbstractDotnetTestMojo.java
@@ -21,6 +21,12 @@ public abstract class AbstractDotnetTestMojo extends AbstractDotnetMojo {
     public void executeInternal() throws MojoFailureException {
         final PluginHelper helper = getPluginHelper();
         ArrayList<String> argsList = new ArrayList<String>(Arrays.asList("dotnet", testCommand, "-c", helper.getBuildConfiguration()));
+        
+        if (helper.getBuildTargetFramework() != "")
+        {
+        	argsList.add("-f");
+        	argsList.add(helper.getBuildTargetFramework());
+        }
         if(outputXml != null) {
             outputXml.getParentFile().mkdirs();
             argsList.add("-xml");

--- a/plugin/src/main/java/org/eobjects/build/DotnetPackMojo.java
+++ b/plugin/src/main/java/org/eobjects/build/DotnetPackMojo.java
@@ -33,9 +33,14 @@ public class DotnetPackMojo extends AbstractDotnetMojo {
         }
 
         final PluginHelper helper = getPluginHelper();
+
         for (File subDirectory : helper.getProjectDirectories()) {
             final String output = helper.getNugetPackageDir(subDirectory).getPath();
-            helper.executeCommand(subDirectory, "dotnet", "pack", "-o", output, "-c", helper.getBuildConfiguration());
+            
+            // Optionally target a particular framework to pack for. Linux-based dotnet cannot build/pack NET45 easily.
+            final String optFramework = helper.getBuildTargetFramework() == "" ? "": "/p:TargetFrameworks=" + helper.getBuildTargetFramework(); 
+
+            helper.executeCommand(subDirectory, "dotnet", "pack", "-o", output, "-c", helper.getBuildConfiguration(), optFramework);
 
             final DotnetProjectFile projectFile = getPluginHelper().getProjectFile(subDirectory);
 

--- a/plugin/src/main/java/org/eobjects/build/PluginHelper.java
+++ b/plugin/src/main/java/org/eobjects/build/PluginHelper.java
@@ -16,10 +16,12 @@ public final class PluginHelper {
     public static final String PROPERTY_BASEDIR = "${project.basedir}";
 
     public static final String PROPERTY_BUILD_DIR = "${project.build.directory}";
+    
+    public static final String PROPERTY_TARGET_FRAMEWORK = "${dotnet.build.framework}";
 
     public static PluginHelper get(Log log, File basedir, Map<String, String> environment, File dotnetPackOutput,
-            String buildConfiguration, boolean skip) {
-        return new PluginHelper(log, basedir, environment, dotnetPackOutput, buildConfiguration, skip);
+            String buildConfiguration, String buildTargetFramework, boolean skip) {
+        return new PluginHelper(log, basedir, environment, dotnetPackOutput, buildConfiguration, buildTargetFramework, skip);
     }
 
     private final File basedir;
@@ -27,15 +29,17 @@ public final class PluginHelper {
     private final boolean skip;
     private final File dotnetPackOutput;
     private final String buildConfiguration;
+    private final String buildTargetFramework;
     private final Log log;
 
     private PluginHelper(Log log, File basedir, Map<String, String> environment, File dotnetPackOutput,
-            String buildConfiguration, boolean skip) {
+            String buildConfiguration, String buildTargetFramework, boolean skip) {
         this.log = log;
         this.basedir = basedir;
         this.environment = environment == null ? Collections.<String, String> emptyMap() : environment;
         this.buildConfiguration = buildConfiguration == null ? "Release" : buildConfiguration;
         this.dotnetPackOutput = dotnetPackOutput == null ? new File("bin") : dotnetPackOutput;
+        this.buildTargetFramework = buildTargetFramework == null ? "" : buildTargetFramework;
         this.skip = skip;
     }
 
@@ -152,6 +156,10 @@ public final class PluginHelper {
 
     public String getBuildConfiguration() {
         return buildConfiguration;
+    }
+
+    public String getBuildTargetFramework() {
+        return buildTargetFramework;
     }
 
     public DotnetProjectFile getProjectFile(File directory) {


### PR DESCRIPTION
 via -Ddotnet.build.framework={framework-moniker}.

Allows building multi-framework projects on machines without a targeting pack for that framework (e.g., NET45/netstandard2.0 and targeting netstandard2.0 on linux machine)